### PR TITLE
Fix DataTable column definitions for data indices

### DIFF
--- a/vistas/js/fichas.js
+++ b/vistas/js/fichas.js
@@ -7,7 +7,7 @@ $('#tblFichas').DataTable({
     "serverSide": true,
     "sAjaxSource": "ajax/serverside/serverside.fichas.php",
     "columns": [
-        { "data": null },
+        { "data": "0" },
         { "data": "1" },
         { "data": "2" },
         { "data": "3" },
@@ -17,12 +17,12 @@ $('#tblFichas').DataTable({
         { "data": null }
     ],
     "columnDefs": [
-        {
-            "targets": [0],
-            "render": function(data, type, row, meta) {
-                return meta.row + 1;
-            },
-        },
+        // {
+        //     "targets": [0],
+        //     "render": function(data, type, row, meta) {
+        //         return meta.row + 1;
+        //     },
+        // },
         {
             "targets": [6],
             "render": function(data, type, row) {


### PR DESCRIPTION
closes #84
Update the DataTable configuration to correctly reference data indices in the column definitions. This change ensures proper data rendering in the table.