### PR TITLE
Ahora la modal de detalles de devolución trae la id del préstamo debido.

### DIFF
--- a/vistas/js/devoluciones.js
+++ b/vistas/js/devoluciones.js
@@ -80,6 +80,8 @@ $(document).ready(function() {
                     `;
                     
                     $('#equiposListContainer').html(equiposTableHtml);
+                    $('#idPrestamo').text(datosPrestamo.id_prestamo);
+                    $('#numeroPrestamo').text(datosPrestamo.id_prestamo);
                     $('#modalVerDetallesPrestamo').modal('show');
 
                 } else {

--- a/vistas/modulos/devoluciones.php
+++ b/vistas/modulos/devoluciones.php
@@ -93,7 +93,7 @@
   <div class="modal-dialog modal-lg" role="document">
     <div class="modal-content">
       <div class="modal-header bg-info">
-        <h5 class="modal-title" id="modalVerUsuarioLabel">Detalles de la Devolución</h5>
+        <h5 class="modal-title" id="modalVerUsuarioLabel">Detalles de la Devolución #<span id="idPrestamo"></span></h5>
         <button type="button" class="close" data-dismiss="modal" aria-label="Close">
           <span aria-hidden="true">&times;</span>
         </button>


### PR DESCRIPTION
Ahora trae la id del préstamo de cuando fue solicitado, y muestra su correcta visualización. Closes #103 
![issue](https://github.com/user-attachments/assets/171daa6d-7e06-48f1-98cf-36a82dda0835)
