### PR TITLE
Mostrar firmas de cada usuario y por quien firmó en el modulo salidas

### DIFF
--- a/vistas/modulos/salidas.php
+++ b/vistas/modulos/salidas.php
@@ -36,6 +36,9 @@
                                         <th>Usuario</th>
                                         <th>Tipo de Préstamo</th>
                                         <th>Estado De Préstamo</th>
+                                        <th>Coor</th>
+                                        <th>Tic</th>
+                                        <th>Alm</th>
                                         <th>Acciones</th>
                                     </tr>
                                 </thead>
@@ -46,26 +49,47 @@
                                     $salidas = Controladorsalidas::ctrMostrarsalidas($item, $valor);
 
                                     foreach ($salidas as $key => $value) {
+                                        $item = "id_prestamo";
+                                        $valor = $value["id_prestamo"];
+                                        $autorizaciones = ControladorAutorizaciones::ctrMostrarAutorizaciones($item, $valor);
+                                        var_dump($salidas);
+                                        if (($value["tipo_prestamo"] == "Reservado")){
                                         echo '
                                         <tr>
                                             <td>' . $value["id_prestamo"] . '</td>
                                             <td>' . $value["nombre"] . '</td>
                                             <td>' . $value["tipo_prestamo"] . '</td>
-                                            <td>' . $value["estado_prestamo"] . '</td>
-                                            <td>
-                                                <div class="btn-group">
-                                                    <button title="Ver detalles" class="btn btn-default btn-sm btnVerDetalles" data-id="' . $value["id_prestamo"] . '" data-toggle="modal" data-target="#modalDetallesPrestamo">
-                                                        <i class="fas fa-eye"></i>
-                                                    </button>
-                                                    <button title="Editar préstamo" class="btn btn-default btn-sm btnEditarPrestamo" data-id="' . $value["id_prestamo"] . '" data-toggle="modal" data-target="#modalEditarPrestamo">
-                                                        <i class="fas fa-edit"></i>
-                                                    </button>
-                                                    <button title="Solicitudes relacionadas" class="btn btn-default btn-sm btnSolicitudesPrestamo" data-id="' . $value["id_prestamo"] . '" data-toggle="modal" data-target="#modalSolicitudesPrestamo">
-                                                        <i class="fas fa-laptop"></i>
-                                                    </button>
-                                                </div>
-                                            </td>
-                                        </tr>';
+                                            <td>' . $value["estado_prestamo"] . '</td>';
+                                                if (isset($autorizaciones["firma_coordinacion"]) && $autorizaciones["firma_coordinacion"] == "Firmado") {
+                                                    echo '<td><input type="checkbox" checked disabled title="Aprobado por '. $_SESSION["nombre"] .' ' . $_SESSION["apellido"] .'">' . '</td>';
+                                                } else {
+                                                    echo '<td><input type="checkbox" disabled title="En trámite...">' . '</td>';
+                                                }
+                                                if (isset($autorizaciones["firma_lider_tic"]) && $autorizaciones["firma_lider_tic"] == "Firmado") {
+                                                    echo '<td><input type="checkbox" checked disabled title="Aprobado por '. $_SESSION["nombre"] .' ' . $_SESSION["apellido"] .'">' . '</td>';
+                                                } else {
+                                                    echo '<td><input type="checkbox" disabled title="En trámite...">' . '</td>';
+                                                }
+                                                if (isset($autorizaciones["firma_almacen"]) && $autorizaciones["firma_almacen"] == "Firmado") {
+                                                    echo '<td><input type="checkbox" checked disabled title="Aprobado por '. $_SESSION["nombre"] .' ' . $_SESSION["apellido"] .'">' . '</td>';
+                                                } else {
+                                                    echo '<td><input type="checkbox" disabled title="En trámite...">' . '</td>';
+                                                }
+                                                echo '<td>
+                                                    <div class="btn-group">
+                                                        <button title="Ver detalles" class="btn btn-default btn-sm btnVerDetalles" data-id="' . $value["id_prestamo"] . '" data-toggle="modal" data-target="#modalDetallesPrestamo">
+                                                            <i class="fas fa-eye"></i>
+                                                        </button>
+                                                        <button title="Editar préstamo" class="btn btn-default btn-sm btnEditarPrestamo" data-id="' . $value["id_prestamo"] . '" data-toggle="modal" data-target="#modalEditarPrestamo">
+                                                            <i class="fas fa-edit"></i>
+                                                        </button>
+                                                        <button title="Solicitudes relacionadas" class="btn btn-default btn-sm btnSolicitudesPrestamo" data-id="' . $value["id_prestamo"] . '" data-toggle="modal" data-target="#modalSolicitudesPrestamo">
+                                                            <i class="fas fa-laptop"></i>
+                                                        </button>
+                                                    </div>
+                                                </td>
+                                            </tr>';
+                                        }
                                     }
                                     ?>
                                 </tbody>

--- a/vistas/modulos/salidas.php
+++ b/vistas/modulos/salidas.php
@@ -52,7 +52,7 @@
                                         $item = "id_prestamo";
                                         $valor = $value["id_prestamo"];
                                         $autorizaciones = ControladorAutorizaciones::ctrMostrarAutorizaciones($item, $valor);
-                                        var_dump($salidas);
+                                        //var_dump($salidas);
                                         if (($value["tipo_prestamo"] == "Reservado")){
                                         echo '
                                         <tr>


### PR DESCRIPTION
# Issue closes #118

En el modulo salidas se implementó la visualización de cada firma, añadiendo las 3 firmas solicitadas (Coordinación, Líder TIC y Almacén) para de esta manera, informarle al usuario como va en trámite su salida de equipo

## Previsualización:

![image](https://github.com/user-attachments/assets/247ee690-23ee-4df7-9ec5-54ed99dbb8ed)
