### PR TITLE
♻️ Se movió el campo de contraseña de la creación al perfil del usuario

### DIFF
--- a/controladores/usuarios.controlador.php
+++ b/controladores/usuarios.controlador.php
@@ -137,12 +137,14 @@ class ControladorUsuarios
             ACTUALIZAR BASE DE DATOS
             =============================================*/
             $tabla = "usuarios";
+            $encriptar = crypt($_POST["nuevoPassword"], '$2a$07$asxx54ahjppf45sd87a5a4dDDGsystemdev$');
             $datos = array(
                 "id_usuario" => $_POST["idUsuario"],
                 "correo_electronico" => $_POST["editarEmail"],
                 "telefono" => $_POST["editarTelefono"],
                 "direccion" => $_POST["editarDireccion"],
                 "genero" => $_POST["editarGenero"],
+                "clave"=> $encriptar,
                 "foto" => $ruta
             );
 
@@ -224,7 +226,7 @@ class ControladorUsuarios
                     imagejpeg($destino, $ruta);
                 }
                 $tabla = "usuarios";
-                $encriptar = crypt($_POST["nuevoPassword"], '$2a$07$asxx54ahjppf45sd87a5a4dDDGsystemdev$');
+                $encriptar = crypt($_POST["nuevoNumeroDocumento"], '$2a$07$asxx54ahjppf45sd87a5a4dDDGsystemdev$');
                 $datos = array(
                     "nombre" => $_POST["nuevoNombre"],
                     "apellido" => $_POST["nuevoApellido"],

--- a/modelos/usuarios.modelo.php
+++ b/modelos/usuarios.modelo.php
@@ -124,13 +124,14 @@ class ModeloUsuarios
         =============================================*/
     static public function mdlEditarPerfil($tabla, $datos)
     {
-        error_log("Consulta SQL: UPDATE $tabla SET tipo_documento = {$datos['tipo_documento']}, numero_documento = {$datos['numero_documento']}, nombre = {$datos['nombre']}, apellido = {$datos['apellido']}, correo_electronico = {$datos['correo_electronico']}, telefono = {$datos['telefono']}, direccion = {$datos['direccion']}, genero = {$datos['genero']}, foto = {$datos['foto']} WHERE id_usuario = {$datos['id_usuario']}");
+        error_log("Consulta SQL: UPDATE $tabla SET tipo_documento = {$datos['tipo_documento']}, numero_documento = {$datos['numero_documento']}, nombre = {$datos['nombre']}, apellido = {$datos['apellido']}, correo_electronico = {$datos['correo_electronico']}, telefono = {$datos['telefono']}, direccion = {$datos['direccion']}, genero = {$datos['genero']}, clave = {$datos['clave']}, foto = {$datos['foto']} WHERE id_usuario = {$datos['id_usuario']}");
         try {
             $stmt = Conexion::conectar()->prepare("UPDATE $tabla SET 
                     correo_electronico = :correo_electronico,
                     telefono = :telefono,
                     direccion = :direccion,
                     genero = :genero,
+                    clave = :clave,
                     foto = :foto
                     WHERE id_usuario = :id_usuario");
 
@@ -138,6 +139,7 @@ class ModeloUsuarios
             $stmt->bindParam(":telefono", $datos["telefono"], PDO::PARAM_STR);
             $stmt->bindParam(":direccion", $datos["direccion"], PDO::PARAM_STR);
             $stmt->bindParam(":genero", $datos["genero"], PDO::PARAM_STR);
+            $stmt->bindParam(":clave", $datos["clave"], PDO::PARAM_STR);
             $stmt->bindParam(":foto", $datos["foto"], PDO::PARAM_STR);
             $stmt->bindParam(":id_usuario", $datos["id_usuario"], PDO::PARAM_INT);
 

--- a/vistas/modulos/menu.php
+++ b/vistas/modulos/menu.php
@@ -454,6 +454,19 @@
               </select>
             </div>
           </div>
+          <!-- row password  -->
+              <div class="form-group">
+                <div class="row">
+                  <div class="col-lg-12">
+                    <div class="input-group ">
+                      <div class="input-group-prepend">
+                        <span class="input-group-text"><i class="fas fa-key"></i></span>
+                      </div>
+                      <input type="password" class="form-control" name="nuevoPassword" placeholder="Password" required>
+                    </div>
+                  </div>
+                </div>
+              </div>
 
           <div class="modal-footer justify-content-between">
             <button type="button" class="btn btn-default" data-dismiss="modal">Cancelar</button>

--- a/vistas/modulos/usuarios.php
+++ b/vistas/modulos/usuarios.php
@@ -505,19 +505,7 @@
               </div>
               <!-- form group -->
 
-              <!-- row password  -->
-              <div class="form-group">
-                <div class="row">
-                  <div class="col-lg-12">
-                    <div class="input-group ">
-                      <div class="input-group-prepend">
-                        <span class="input-group-text"><i class="fas fa-key"></i></span>
-                      </div>
-                      <input type="password" class="form-control" name="nuevoPassword" placeholder="Password" required>
-                    </div>
-                  </div>
-                </div>
-              </div>
+              
               <!-- form group -->
               <div class="modal-footer justify-content-between">
                 <button type="button" class="btn btn-default" data-dismiss="modal">Cancelar</button>


### PR DESCRIPTION
### 📌 Descripción del Pull Request

Este *pull request* incluye la solución aplicada al módulo de **usuarios**, específicamente en las siguientes áreas:

- 🔧 **Modal de Agregar Usuario**:  
  - Se eliminó el campo de input para la contraseña (`password`) con el fin de simplificar el proceso de creación de usuarios desde el panel administrativo.
<img width="283" alt="image" src="https://github.com/user-attachments/assets/e6bb0a8f-f13c-4df3-89c4-1dbdba7b514b" />

- ✏️ **Modal de Editar Perfil**:  
  - Se agregó el campo de input para la contraseña (`password`) permitiendo que el propio usuario pueda actualizar su clave desde la edición de su perfil.
<img width="281" alt="image" src="https://github.com/user-attachments/assets/f457bd3b-5f94-446f-bde6-0a94b3b520b1" />

Estos cambios responden a la necesidad de mejorar la seguridad y la experiencia de usuario, delegando el control de la contraseña al usuario final.

---

### ✅ Cambios realizados

- Eliminado el campo `password` de la **modal de creación de usuario**.
- Agregado el campo `password` en la **modal de edición de perfil** del usuario.

---

### 🧪 Pruebas realizadas

- Se verificó que la creación de usuarios funcione correctamente sin el campo `password`.
- Se comprobó que el campo de contraseña en la edición de perfil actualice correctamente los datos en la base de datos.