### PR TITLE
🎨 Sincronizar color de callout y badge según estado del préstamo en la modal de autorizaciones

### DIFF
--- a/vistas/js/autorizaciones.js
+++ b/vistas/js/autorizaciones.js
@@ -99,6 +99,47 @@ $(document).on("click", ".btnVerDetallePrestamo_Autorizar", function () {
       $("#detalleFechaFin").text(fechaFin);
       $("#detalleMotivoPrestamo").text(respuesta["motivo"]);
       $("#estadoPrestamo").text(respuesta["estado_prestamo"]);
+      $("#estadoCallout")
+            .removeClass("callout-success callout-warning callout-danger callout-primary");
+
+        // Agregar nueva clase según estado
+                switch (respuesta["estado_prestamo"]) {
+                    case "Autorizado":
+                        $("#estadoCallout").addClass("callout-success");
+                        
+                        break;
+                    case "Pendiente":
+                        $("#estadoCallout").addClass("callout-warning");
+                        
+                        break;
+                    case "Rechazado":
+                        $("#estadoCallout").addClass("callout-danger");
+                        
+                        break;
+                    case "Tramite":
+                        $("#estadoCallout").addClass("callout-info");
+                        
+                        break;
+                }
+                $("#estadoPrestamo")
+                .removeClass("badge-success badge-warning badge-danger badge-primary");
+
+            // Agregar clase según estado
+            switch (respuesta["estado_prestamo"]) {
+                case "Autorizado":
+                    $("#estadoPrestamo").addClass("badge-success");
+                    break;
+                case "Pendiente":
+                    $("#estadoPrestamo").addClass("badge-warning");
+                    break;
+                case "Rechazado":
+                    $("#estadoPrestamo").addClass("badge-danger");
+                    break;
+                case "Tramite":
+                    $("#estadoPrestamo").addClass("badge-primary");
+                    break;
+                 
+            }
       datosUsuario = new FormData();
       datosUsuario.append("idUsuario", respuesta["id_usuario"]);
       //traemos los datos del usuario

--- a/vistas/js/salidas.js
+++ b/vistas/js/salidas.js
@@ -53,7 +53,7 @@ $(document).on('click', '.btnVerDetalles', function () {
                         
                         break;
                     case "Tramite":
-                        $("#estadoCallout").addClass("callout-primary");
+                        $("#estadoCallout").addClass("callout-info");
                         
                         break;
                 }

--- a/vistas/modulos/autorizaciones.php
+++ b/vistas/modulos/autorizaciones.php
@@ -197,7 +197,7 @@
             <!-- Estado -->
             <div class="row">
               <div class="col-12">
-                <div class="callout callout-success">
+                <div class="callout callout-success" id="estadoCallout">
                   <h5><i class="fas fa-check"></i> Estado:</h5>
                   <span class="badge badge-success badge-lg" id="estadoPrestamo">Autorizado</span>
                 </div>


### PR DESCRIPTION
## 🎯 Objetivo

Este Pull Request introduce una mejora visual en la **modal de autorizaciones**, haciendo que el color de la caja (`callout`) y del estado (`badge`) cambien dinámicamente según el estado del préstamo recibido desde el backend.

---

## ✅ Cambios realizados

- Se agregó el atributo `id="estadoCallout"` al contenedor `callout` de la modal.
- Se implementó lógica en JavaScript para eliminar clases anteriores (`callout-*` y `badge-*`) y agregar la clase correspondiente dependiendo del estado (`Autorizado`, `Pendiente`, `Rechazado`, `Trámite`).
<img width="632" height="71" alt="image" src="https://github.com/user-attachments/assets/da1696b6-9f24-4af0-b1f0-1cee74fe9259" />


---


