### PR TITLE
✅ Pull Request – Mostrar motivo del rechazo en el detalle del préstamo

### DIFF
--- a/vistas/js/mis-solicitudes.js
+++ b/vistas/js/mis-solicitudes.js
@@ -26,15 +26,21 @@ $(document).on("click", ".btnVerDetalle", function () {
 
         // Agregar nueva clase según estado
                 switch (respuesta["estado_prestamo"]) {
-                    case "Autorizado"&& "Prestado":
+                    case "Autorizado":
                         $("#estadoCallout").addClass("callout-success");
+
+                    case "Prestado":
+                        $("#estadoCallout").addClass("callout-success");    
                         
                         break;
                     case "Pendiente":
                         $("#estadoCallout").addClass("callout-warning");
                         
                         break;
-                    case "Rechazado"&&"Devuelto":
+                    case "Rechazado":
+                        $("#estadoCallout").addClass("callout-danger");
+
+                    case "Devuelto":
                         $("#estadoCallout").addClass("callout-danger");
                         
                         break;
@@ -49,21 +55,38 @@ $(document).on("click", ".btnVerDetalle", function () {
 
             // Agregar clase según estado
             switch (respuesta["estado_prestamo"]) {
-                case "Autorizado" && "Prestado":
+                case "Autorizado":
                     $("#estadoPrestamo").addClass("badge-success");
+
+                   case "Prestado":
+                    $("#estadoPrestamo").addClass("badge-success");
+
                     break;
                 case "Pendiente":
                     $("#estadoPrestamo").addClass("badge-warning");
                     break;
-                case "Rechazado"&&"Devuelto":
+
+                case "Rechazado":
                     $("#estadoPrestamo").addClass("badge-danger");
                     break;
+
+                    case "Devuelto":
+                    $("#estadoPrestamo").addClass("badge-danger");
+                    break;
+                    
                 case "Tramite":
                     $("#estadoPrestamo").addClass("badge-primary");
                     break;
                 
                  
             }
+            if (respuesta["estado_prestamo"] === "Rechazado") {
+              $("#motivoRechazoTexto")
+                  .text("Motivo de rechazo: " + (respuesta["motivo_rechazo"] || "No especificado"))
+                  .show();
+          } else {
+              $("#motivoRechazoTexto").hide();
+          }
        
       datosDetalle = new FormData();
       datosDetalle.append("accion", "mostrarPrestamoDetalle");

--- a/vistas/modulos/mis-solicitudes.php
+++ b/vistas/modulos/mis-solicitudes.php
@@ -204,6 +204,8 @@ if ($respuesta["estado"] == "inactivo") {
             <div class="callout callout-success w-100" id="estadoCallout">
               <h5><i class="fas fa-check"></i> Estado:</h5>
               <span class="badge badge-success badge-lg" id="estadoPrestamo">Autorizado</span>
+               <br>
+                 <small id="motivoRechazoTexto" class="text-danger" style="display: none;"></small>
             </div>
           </div>
         </div>


### PR DESCRIPTION
🛠️ Descripción del cambio:
Se solucionó un problema en la vista de detalle del préstamo (#4), donde no se mostraba el motivo específico del rechazo y los colores de las cajas ya que no pintaban los nuevos estados. Esto causaba falta de claridad para el solicitante y el personal encargado de aprobar o revisar las solicitudes.

🐞 Error original:
Descripción:
En el detalle de un préstamo con estado “Rechazado”, no aparecía el motivo del rechazo, lo cual dificultaba la transparencia y trazabilidad del proceso.

Pasos para reproducir:

Ir al módulo de Préstamos.

Abrir el detalle de un préstamo rechazado.

Observar que solo aparece el estado “Rechazado”, sin ningún motivo o explicación.

Comportamiento esperado:
Debería mostrarse un mensaje como:

Rechazado - Falta de disponibilidad
Rechazado - Información incompleta, etc.

✅ Solución implementada:
Se agregó un campo adicional junto al estado que muestra el motivo del rechazo.

El motivo es dinámico y se extrae correctamente de la base de datos en caso de que el préstamo esté marcado como rechazado.

La interfaz fue ajustada para presentar de forma clara y legible este nuevo texto.
<img width="1893" height="890" alt="Captura de pantalla 2025-07-22 083620" src="https://github.com/user-attachments/assets/95820e70-dbe9-46f9-b77e-add024daf309" />



🚦 Prioridad: Alta
📈 Impacto: Medio – Mejora la transparencia hacia los usuarios finales.
✅ Checklist:
 Se muestra correctamente el motivo del rechazo en la interfaz.

 Se probó visualmente con distintos estados.

 No se afectaron préstamos con estado distinto a “Rechazado”.
 closes #203 