### PR TITLE
permite que acerca de, se muestre en un celular

### DIFF
--- a/vistas/modulos/cabezote.php
+++ b/vistas/modulos/cabezote.php
@@ -5,8 +5,11 @@
     <li class="nav-item">
       <a class="nav-link" data-widget="pushmenu" href="#" role="button"><i class="fas fa-bars"></i></a>
     </li>
-    <li class="nav-item d-none d-sm-inline-block">
-      <a href="acerca-de" class="nav-link">Acerca de</a>
+    <li class="nav-item">
+      <a href="acerca-de" class="nav-link" title="Acerca de">
+        <span class="d-none d-sm-inline">Acerca de</span>
+        <i class="fas fa-info-circle d-sm-none"></i>
+      </a>
     </li>
     <li>
       <pre><?php


### PR DESCRIPTION
Cordial Saludo

Actualmente no se muestra el acerca de
![Screenshot_20250722_153132_com_android_chrome_ChromeTabbedActivity_edit_34071118754500](https://github.com/user-attachments/assets/83113320-8ac7-455b-a99e-1491652a1e22)

Con este cambio va permitir que aparezca ℹ️ y muestra lo de acerca de 
![Screenshot_20250722_154501_com_android_chrome_ChromeTabbedActivity_edit_35025654419136](https://github.com/user-attachments/assets/e594ce58-97c3-45b6-a95c-9a707a0ce579)
Y no afecta cuando se ve la vista en un pc
![Screenshot_20250722_154734_com_android_chrome_ChromeTabbedActivity_edit_35048841240169](https://github.com/user-attachments/assets/8337eee8-4c07-4b45-b500-5e1019682a8d)
