### PR TITLE
solucionando error de el documento predeterminado si es rol instructor o otro rol q puede hacer solicitudes

### DIFF
--- a/vistas/plantilla.php
+++ b/vistas/plantilla.php
@@ -115,6 +115,7 @@ session_start();
     echo '<script>
         const usuarioActual = {
             id: ' . $_SESSION['id_usuario'] . ',
+            cedula: "'. $_SESSION['numero_documento']. '",
             permisos: ' . json_encode($_SESSION['permisos']) . '  
         }
     </script>';


### PR DESCRIPTION
asi estaba plantilla.php, sin llamar la cedula

<img width="1244" height="437" alt="image" src="https://github.com/user-attachments/assets/51dff67c-187f-49e0-94ad-c7b8d504b64b" />



asi quedo en plantilla.php, se agrego la cedula q llama el numero_documento


<img width="1317" height="500" alt="image" src="https://github.com/user-attachments/assets/34afcfd8-22b9-41ae-8a41-3b12c6dc605f" />



att, alonso arboleda
