### PR TITLE
configurar el rango de fechas en español

### DIFF
--- a/vistas/js/plantilla.js
+++ b/vistas/js/plantilla.js
@@ -103,6 +103,18 @@ var Toast = Swal.mixin({
   timer: 2000
 });
 
-$('#reservation').daterangepicker();
-
-
+$('#reservation').daterangepicker({
+  locale: {
+    format: 'DD/MM/YYYY',
+    separator: ' - ',
+    applyLabel: 'Aplicar',
+    cancelLabel: 'Cancelar',
+    fromLabel: 'De',
+    toLabel: 'A',
+    customRangeLabel: 'Rango Personalizado',
+    weekLabel: 'S',
+    daysOfWeek: ['Dom', 'Lun', 'Mar', 'Mié', 'Jue', 'Vie', 'Sáb'],
+    monthNames: ['Enero', 'Febrero', 'Marzo', 'Abril', 'Mayo', 'Junio', 'Julio', 'Agosto', 'Septiembre', 'Octubre', 'Noviembre', 'Diciembre'],
+    firstDay: 1
+  }
+});


### PR DESCRIPTION
Cordial Saludo closes #222 

Lo que se añadió permitirá visualizar el calendario en español(todo este funcionamiento es opcional)
<img width="379" height="225" alt="image" src="https://github.com/user-attachments/assets/e7411e81-7d28-4769-af75-4c0fcf89cafa" />

