### PR TITLE
fix: incluir inicio.php cuando no se encuentra ningún módulo válido

### DIFF
--- a/vistas/plantilla.php
+++ b/vistas/plantilla.php
@@ -156,6 +156,8 @@ session_start();
       } else {
         include "modulos/error404.php";
       }
+    } else {
+      include "modulos/inicio.php";
     }
 
     include "modulos/footer.php";


### PR DESCRIPTION
Cordial Saludo closes #243 (opcional)

Ya se agregó el else { }
<img width="1366" height="684" alt="image" src="https://github.com/user-attachments/assets/ad6d2688-ec12-4ca9-9a42-a2f24917b903" />

Ahora cuando se implemente en adso.click/hermes <- se va a mostrar de esta manera