### PR TITLE
Mostrar y ocultar contraseña en editar perfil

### DIFF
--- a/vistas/modulos/menu.php
+++ b/vistas/modulos/menu.php
@@ -438,10 +438,10 @@
                   <div class="input-group-prepend">
                     <span class="input-group-text"><i class="fas fa-key"></i></span>
                   </div>
-                  <input type="password" class="form-control" name="nuevoPassword" placeholder="Password">
+                  <input type="password" class="form-control" name="nuevoPassword" id="nuevoPassword" placeholder="Password">
                   <div class="input-group-append">
               <div class="input-group-text" onclick="togglePassword()" style="cursor: pointer;">
-                <span class="fas fa-eye" id="toggleIcon"></span>
+                <span class="fas fa-eye-slash" id="toggleIcon"></span>
               </div>
               </div>
                 </div>
@@ -466,3 +466,18 @@
   <!-- /.modal-dialog -->
 </div>
 <!-- /.modal -->
+<script>
+function togglePassword() {
+  const passwordField = document.getElementById('nuevoPassword');
+  const toggleIcon = document.getElementById('toggleIcon');
+  if (passwordField.type === 'password') {
+    passwordField.type = 'text';
+    toggleIcon.classList.remove('fa-eye-slash');
+    toggleIcon.classList.add('fa-eye');
+  } else {
+    passwordField.type = 'password';
+    toggleIcon.classList.remove('fa-eye');
+    toggleIcon.classList.add('fa-eye-slash');
+  }
+}
+</script>


### PR DESCRIPTION
Cordial Saludo closes #249 (opcional)

Se agregó el script que permitirá al usuario ver su contraseña en el editar
1. Tambien se solucionó la logicá con el icono del ojo
<img width="357" height="81" alt="image" src="https://github.com/user-attachments/assets/22fe4ef6-2d8c-434d-a96b-f751e9f08440" />

Ahora se ve así

<img width="358" height="84" alt="image" src="https://github.com/user-attachments/assets/fea3067a-b2ac-442f-b187-14bef16bb7c3" />


